### PR TITLE
Fixing maximum calculation to work on series of different lengths 

### DIFF
--- a/src/components/views/PolicyModel/PolicyModel/parseModels.js
+++ b/src/components/views/PolicyModel/PolicyModel/parseModels.js
@@ -165,8 +165,10 @@ export default function parseModelCurves(
             curves[state].curves["CF_" + column].yMax =
               curves[state].curves["CF_" + column].yMax >
               counterfactualRun[index][column]
-                ? curves[state].curves["CF_" + column].yMax
-                : counterfactualRun[index][column];
+                ?
+                  ? curves[state].curves["CF_" + column].yMax
+                  : counterfactualRun[index][column];
+                : 0
           }
 
           // doing yMax as we go because we're already looping anyway

--- a/src/components/views/PolicyModel/PolicyModel/parseModels.js
+++ b/src/components/views/PolicyModel/PolicyModel/parseModels.js
@@ -162,11 +162,14 @@ export default function parseModelCurves(
 
           // Add Counterfactual curves with CF prefix
           if (counterfactualSelected) {
-            curves[state].curves["CF_" + column].yMax =
-              curves[state].curves["CF_" + column].yMax >
-              counterfactualRun[index][column]
-                ? curves[state].curves["CF_" + column].yMax
-                : counterfactualRun[index][column];
+            curves[state].curves["CF_" + column].yMax = counterfactualRun[index]
+              ? counterfactualRun[index][column]
+                ? counterfactualRun[index][column] >
+                  curves[state].curves["CF_" + column].yMax
+                  ? counterfactualRun[index][column]
+                  : curves[state].curves["CF_" + column].yMax
+                : 0
+              : curves[state].curves["CF_" + column].yMax;
           }
 
           // doing yMax as we go because we're already looping anyway

--- a/src/components/views/PolicyModel/PolicyModel/parseModels.js
+++ b/src/components/views/PolicyModel/PolicyModel/parseModels.js
@@ -164,10 +164,11 @@ export default function parseModelCurves(
           if (counterfactualSelected) {
             curves[state].curves["CF_" + column].yMax =
               curves[state].curves["CF_" + column].yMax >
-              counterfactualRun[index][column]
+              counterfactualRun[index]
                 ?
-                  ? curves[state].curves["CF_" + column].yMax
-                  : counterfactualRun[index][column];
+                counterfactualRun[index][column]
+                    ? curves[state].curves["CF_" + column].yMax
+                    : counterfactualRun[index][column]
                 : 0
           }
 


### PR DESCRIPTION
Dealing with situations where `counterfactualRun[index][column]` is undefined