### PR TITLE
Explicitly disable the caseload popup at the end of the actuals, inst…

### DIFF
--- a/src/components/views/PolicyModel/PolicyModel/PolicyModel.js
+++ b/src/components/views/PolicyModel/PolicyModel/PolicyModel.js
@@ -148,6 +148,7 @@ const PolicyModel = ({ setLoading, setPage }) => {
           actuals: caseloadPoints,
           actuals_yMax: seriesMax,
           average: averagePoints,
+          actuals_end: caseloadPoints.slice(-1)[0].x,
         };
       } else {
         modelCurves[selectedStates[0]].curves["dead"] = {
@@ -155,6 +156,7 @@ const PolicyModel = ({ setLoading, setPage }) => {
           actuals: caseloadPoints,
           actuals_yMax: seriesMax,
           average: averagePoints,
+          actuals_end: caseloadPoints.slice(-1)[0].x,
         };
       }
 

--- a/src/components/views/PolicyModel/PolicyPlot/InspectDayCursor/InspectDayCursor.js
+++ b/src/components/views/PolicyModel/PolicyPlot/InspectDayCursor/InspectDayCursor.js
@@ -169,7 +169,8 @@ const InspectDailyCursor = props => {
   });
   return (
     <>
-      {(props.activeTab === "caseload" && popupDate < new Date()) ||
+      {(props.activeTab === "caseload" &&
+        popupDate < props.data.curves[yAxis].actuals_end) ||
       (props.activeTab === "interventions" && popupDate > new Date()) ? (
         <VictoryPortal>
           <g>


### PR DESCRIPTION
…ead of at today, since the popup has access to the model

This is still a little broken because of the difference between days starting and data starting... need to fix that 