### PR TITLE
Allowing timezone on the popup to be local, since the date parsing fo…

### DIFF
--- a/src/components/views/PolicyModel/PolicyPlot/InspectDayCursor/InspectDayCursor.js
+++ b/src/components/views/PolicyModel/PolicyPlot/InspectDayCursor/InspectDayCursor.js
@@ -35,12 +35,11 @@ const formatActuals = number =>
 const InspectDailyCursor = props => {
   const [xOffset, yOffset] = [500 - props.x < 140 ? 4.75 : -4.75, 0];
 
-  const popupDate = new Date(props.datum.x);
+  const popupDate = props.datum.x;
   const dateString = popupDate.toLocaleString("default", {
     month: "short",
     day: "numeric",
     year: "numeric",
-    timeZone: "UTC",
   });
 
   let latestIntervention = props.data.interventions


### PR DESCRIPTION
…ead of at today, since the popup has access to the model

This is still a little broken because of the difference between days starting and data starting... need to fix that 